### PR TITLE
feat(message): implement delete specific message endpoint

### DIFF
--- a/server/usingDatabase/controllers/MessageController.js
+++ b/server/usingDatabase/controllers/MessageController.js
@@ -115,6 +115,32 @@ class MessageController {
       });
     });
   }
+
+  /**
+  * @method deleteMessage
+  * @description Delete a specific messages
+  * @static
+  * @param {object} req - The request object
+  * @param {object} res - The response object
+  * @returns {object} JSON response
+  * @memberof MessageController
+  */
+  static deleteMessage(req, res) {
+    const { id } = req.params;
+
+    const query = 'DELETE FROM messages WHERE id = $1';
+
+    pool.query(query, [id], err => {
+      if (err) {
+        return ErrorHandler.databaseError(res);
+      }
+
+      res.status(200).send({
+        status: res.statusCode,
+        data: [{ message: 'Message record has been deleted' }],
+      });
+    });
+  }
 }
 
 export default MessageController;

--- a/server/usingDatabase/routes/router.js
+++ b/server/usingDatabase/routes/router.js
@@ -39,4 +39,9 @@ router.get('/messages/:id',
   MessageValidator.validateId,
   MessageController.getMessage);
 
+
+router.delete('/messages/:id',
+  MessageValidator.validateId,
+  MessageController.deleteMessage);
+
 export default router;

--- a/server/usingDatabase/tests/messagesSpec.js
+++ b/server/usingDatabase/tests/messagesSpec.js
@@ -162,3 +162,53 @@ describe('/GET Messages routes', () => {
       });
   });
 });
+
+describe('/DELETE Messages route', () => {
+  it('should return an error if id is invalid', done => {
+    const message = {
+      id: 'tt',
+    };
+    chai
+      .request(app)
+      .delete(`/api/v2/messages/${message.id}`)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('The given id is invalid');
+        done(err);
+      });
+  });
+
+  it('should return an error if message does not exist', done => {
+    const message = {
+      id: 177,
+    };
+    chai
+      .request(app)
+      .delete(`/api/v2/messages/${message.id}`)
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Message record does not exist');
+        done(err);
+      });
+  });
+
+  it('should delete a specific email record', done => {
+    const message = {
+      id: 1,
+    };
+    chai
+      .request(app)
+      .delete(`/api/v2/messages/${message.id}`)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data[0]).to.have.property('message')
+          .eql('Message record has been deleted');
+        done(err);
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?

- This PR setup test suite and implements delete specific message endpoint



#### Description of Tasks

- Setup test suite for this endpoint
- Define endpoint and method for delete specific message
- Add the route
- Test with Postman
- Ensure spec tests for this endpoint pass



#### How should this be manually tested?

- Make a delete request to `api/v2/messages/<message-id>` endpoint



#### Relevant pivotal tracker story

- [164609200](https://www.pivotaltracker.com/story/show/164609200)



#### Screenshots
![Screenshot (13)](https://user-images.githubusercontent.com/43535158/54475505-3fd39780-47f2-11e9-96a8-266917e65ec8.png)
