### PR TITLE
feat(group): implement group name update

### DIFF
--- a/server/usingDatabase/controllers/GroupController.js
+++ b/server/usingDatabase/controllers/GroupController.js
@@ -75,6 +75,27 @@ class GroupController {
       });
     });
   }
+
+  static updateGroupName(req, res) {
+    const memberId = req.user.id;
+    let { name } = req.body;
+    name = name.trim();
+    const { id } = req.params;
+    const values = [name, id, memberId];
+    const query = `UPDATE groups SET name = $1 FROM group_members WHERE groups.id = $2
+      AND groups.id = group_members.group_id AND group_members.member_id = $3
+      RETURNING groups.id, groups.name, group_members.role`;
+
+    pool.query(query, values, (err, data) => {
+      if (err) {
+        return ErrorHandler.databaseError(res);
+      }
+      res.status(200).send({
+        status: res.statusCode,
+        data: [data.rows[0]],
+      });
+    });
+  }
 }
 
 export default GroupController;

--- a/server/usingDatabase/middlewares/GroupValidator.js
+++ b/server/usingDatabase/middlewares/GroupValidator.js
@@ -1,5 +1,6 @@
 import ErrorHandler from '../../utils/ErrorHandler';
 import Helper from '../../utils/Helper';
+import pool from '../models/database';
 
 /**
  * @class GroupValidator
@@ -17,16 +18,16 @@ class GroupValidator {
   * @returns {object} next
   * @memberof GroupValidator
   */
-  static validateCreateGroup(req, res, next) {
+  static validateGroupName(req, res, next) {
     const regEx = Helper.regEx();
     let { name } = req.body;
-
-    name = name.trim();
 
     if (!name) {
       return ErrorHandler.validationError(res, 400,
         'Group must have a name');
     }
+
+    name = name.trim();
 
     if (name.length > 50 || name.length < 3) {
       return ErrorHandler.validationError(res, 400,
@@ -38,6 +39,63 @@ class GroupValidator {
         'Invalid input! name can only contain alphabets, underscores and digits');
     }
     return next();
+  }
+
+  static validateExistingGroup(req, res, next) {
+    const regEx = Helper.regEx();
+    const { id } = req.params;
+
+    if (!regEx.id.test(id) || (id === '0')) {
+      return ErrorHandler.validationError(res, 400, 'The given id is invalid');
+    }
+
+    const query = 'SELECT * FROM groups WHERE id = $1';
+
+    pool.query(query, [id], (err, data) => {
+      if (err) {
+        return ErrorHandler.databaseError(res);
+      }
+      if (data.rowCount < 1) {
+        return ErrorHandler.validationError(res, 404, 'Group does not exist');
+      }
+      return next();
+    });
+  }
+
+  static validateMember(req, res, next) {
+    const { id } = req.params;
+    const memberId = req.user.id;
+    const values = [id, memberId];
+    const query = `SELECT * FROM groups, group_members WHERE groups.id = $1 
+      AND group_members.member_id = $2 AND groups.id = group_members.group_id`;
+
+    pool.query(query, values, (err, data) => {
+      if (err) {
+        return ErrorHandler.databaseError(res);
+      }
+      if (data.rowCount < 1) {
+        return ErrorHandler.validationError(res, 404, 'You do not belong to this group');
+      }
+      return next();
+    });
+  }
+
+  static validateAdmin(req, res, next) {
+    const { id } = req.params;
+    const memberId = req.user.id;
+    const values = ['admin', memberId, id];
+    const query = `SELECT * FROM group_members WHERE role = $1
+      AND member_id = $2 AND group_id = $3`;
+
+    pool.query(query, values, (err, data) => {
+      if (err) {
+        return ErrorHandler.databaseError(res);
+      }
+      if (data.rowCount < 1) {
+        return ErrorHandler.validationError(res, 401, 'Only an admin can edit this group');
+      }
+      return next();
+    });
   }
 }
 

--- a/server/usingDatabase/routes/router.js
+++ b/server/usingDatabase/routes/router.js
@@ -57,11 +57,19 @@ router.delete('/messages/:id',
 
 router.post('/groups',
   Auth.userAuth,
-  GroupValidator.validateCreateGroup,
+  GroupValidator.validateGroupName,
   GroupController.createGroup);
 
 router.get('/groups',
   Auth.userAuth,
   GroupController.getGroups);
+
+router.patch('/groups/:id/name',
+  Auth.userAuth,
+  GroupValidator.validateGroupName,
+  GroupValidator.validateExistingGroup,
+  GroupValidator.validateMember,
+  GroupValidator.validateAdmin,
+  GroupController.updateGroupName);
 
 export default router;

--- a/server/usingDatabase/tests/groupsSpec.js
+++ b/server/usingDatabase/tests/groupsSpec.js
@@ -181,3 +181,217 @@ describe('/GET Group route', () => {
       });
   });
 });
+
+describe('/PATCH Group route', () => {
+  it('should return an error if user is not authenticated', done => {
+    const group = {
+      id: 1,
+      name: 'Champions',
+    };
+    chai
+      .request(app)
+      .patch(`/api/v2/groups/${group.id}/name`)
+      .set('authorization', '')
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(401);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('You are not logged in');
+        done(err);
+      });
+  });
+
+  it('should return an error if token cannot be authenticated', done => {
+    const group = {
+      id: 1,
+      name: 'Champions',
+    };
+    chai
+      .request(app)
+      .patch(`/api/v2/groups/${group.id}/name`)
+      .set('authorization', 'urgjrigriirkjwUHJFRFFJrgfr')
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(401);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Authentication failed');
+        done(err);
+      });
+  });
+
+  it('should return an error if name field is empty', done => {
+    const group = {
+      id: 1,
+      name: '',
+    };
+    chai
+      .request(app)
+      .patch(`/api/v2/groups/${group.id}/name`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Group must have a name');
+        done(err);
+      });
+  });
+
+  it('should return an error if name field characters is less than 3 or greater than 50', done => {
+    const group = {
+      id: 1,
+      name: 'lorem ipsum tities lorem ipsum tities lorem ipsum tities lorem ipsum tities',
+    };
+    chai
+      .request(app)
+      .patch(`/api/v2/groups/${group.id}/name`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql(`name contains ${group.name.length} characters, must be between 3 and 50`);
+        done(err);
+      });
+  });
+
+  it('should return an error if group name format is invalid', done => {
+    const group = {
+      id: 1,
+      name: '@hjj*..-hg',
+    };
+    chai
+      .request(app)
+      .patch(`/api/v2/groups/${group.id}/name`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Invalid input! name can only contain alphabets, underscores and digits');
+        done(err);
+      });
+  });
+
+  it('should return an error if id format is invalid', done => {
+    const group = {
+      id: 'ty',
+      name: 'Champions',
+    };
+    chai
+      .request(app)
+      .patch(`/api/v2/groups/${group.id}/name`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('The given id is invalid');
+        done(err);
+      });
+  });
+
+  it('should return an error if group does not exist', done => {
+    const group = {
+      id: 4567,
+      name: 'Champions',
+    };
+    chai
+      .request(app)
+      .patch(`/api/v2/groups/${group.id}/name`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Group does not exist');
+        done(err);
+      });
+  });
+
+  it('should return an error if group does not exist', done => {
+    const group = {
+      id: 4567,
+      name: 'Champions',
+    };
+    chai
+      .request(app)
+      .patch(`/api/v2/groups/${group.id}/name`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Group does not exist');
+        done(err);
+      });
+  });
+
+  it('should return an error if user does not belong to the group', done => {
+    const group = {
+      id: 3,
+      name: 'Champions',
+    };
+    chai
+      .request(app)
+      .patch(`/api/v2/groups/${group.id}/name`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('You do not belong to this group');
+        done(err);
+      });
+  });
+
+  it('should return an error if user is not an admin', done => {
+    const group = {
+      id: 2,
+      name: 'Champions',
+    };
+    chai
+      .request(app)
+      .patch(`/api/v2/groups/${group.id}/name`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(401);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Only an admin can edit this group');
+        done(err);
+      });
+  });
+
+  it('should rename the group if credentials are valid', done => {
+    const group = {
+      id: 1,
+      name: 'Champions',
+    };
+    chai
+      .request(app)
+      .patch(`/api/v2/groups/${group.id}/name`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data).to.be.an('array');
+        expect(res.body.data[0]).to.have.property('name')
+          .eql(`${group.name}`);
+        expect(res.body.data[0]).to.have.property('role')
+          .eql('admin');
+        done(err);
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?


This PR setup test suite and implements group name update


#### Description of Tasks

- Setup test suite for this endpoint
- Define endpoint and method for patch group name
- Add the route
- Secure the route
- Test with Postman
- Ensure spec tests for this endpoint pass


#### How should this be manually tested?

Make a patch request to `/api/v2/groups/<group-id>/name`


#### Background context

Only group admin can edit group name


#### Relevant pivotal tracker story

[164614223](https://www.pivotaltracker.com/story/show/164614223)



#### Screenshot


![Screenshot (16)](https://user-images.githubusercontent.com/43535158/54497185-ece40800-48f7-11e9-8500-445e2ea723a8.png)

