### PR TITLE
feat(group): implement delete group endpoint

### DIFF
--- a/server/usingDatabase/controllers/GroupController.js
+++ b/server/usingDatabase/controllers/GroupController.js
@@ -77,13 +77,11 @@ class GroupController {
   }
 
   static updateGroupName(req, res) {
-    const memberId = req.user.id;
     let { name } = req.body;
     name = name.trim();
     const { id } = req.params;
-    const values = [name, id, memberId];
+    const values = [name, id];
     const query = `UPDATE groups SET name = $1 FROM group_members WHERE groups.id = $2
-      AND groups.id = group_members.group_id AND group_members.member_id = $3
       RETURNING groups.id, groups.name, group_members.role`;
 
     pool.query(query, values, (err, data) => {
@@ -93,6 +91,24 @@ class GroupController {
       res.status(200).send({
         status: res.statusCode,
         data: [data.rows[0]],
+      });
+    });
+  }
+
+  static deleteGroup(req, res) {
+    const { id } = req.params;
+    const query = 'DELETE FROM groups WHERE id = $1';
+    const value = [id];
+
+    pool.query(query, value, err => {
+      if (err) {
+        return ErrorHandler.databaseError(res);
+      }
+      return res.status(200).send({
+        status: res.statusCode,
+        data: [{
+          message: 'Group deleted successfully',
+        }],
       });
     });
   }

--- a/server/usingDatabase/middlewares/GroupValidator.js
+++ b/server/usingDatabase/middlewares/GroupValidator.js
@@ -92,7 +92,7 @@ class GroupValidator {
         return ErrorHandler.databaseError(res);
       }
       if (data.rowCount < 1) {
-        return ErrorHandler.validationError(res, 401, 'Only an admin can edit this group');
+        return ErrorHandler.validationError(res, 401, 'Require Admin access');
       }
       return next();
     });

--- a/server/usingDatabase/routes/router.js
+++ b/server/usingDatabase/routes/router.js
@@ -72,4 +72,11 @@ router.patch('/groups/:id/name',
   GroupValidator.validateAdmin,
   GroupController.updateGroupName);
 
+router.delete('/groups/:id',
+  Auth.userAuth,
+  GroupValidator.validateExistingGroup,
+  GroupValidator.validateMember,
+  GroupValidator.validateAdmin,
+  GroupController.deleteGroup);
+
 export default router;

--- a/server/usingDatabase/tests/groupsSpec.js
+++ b/server/usingDatabase/tests/groupsSpec.js
@@ -316,25 +316,6 @@ describe('/PATCH Group route', () => {
       });
   });
 
-  it('should return an error if group does not exist', done => {
-    const group = {
-      id: 4567,
-      name: 'Champions',
-    };
-    chai
-      .request(app)
-      .patch(`/api/v2/groups/${group.id}/name`)
-      .set('authorization', `Bearer ${userToken}`)
-      .send(group)
-      .end((err, res) => {
-        expect(res).to.have.status(404);
-        expect(res.body).to.be.an('object');
-        expect(res.body).to.have.property('error')
-          .eql('Group does not exist');
-        done(err);
-      });
-  });
-
   it('should return an error if user does not belong to the group', done => {
     const group = {
       id: 3,
@@ -368,7 +349,7 @@ describe('/PATCH Group route', () => {
         expect(res).to.have.status(401);
         expect(res.body).to.be.an('object');
         expect(res.body).to.have.property('error')
-          .eql('Only an admin can edit this group');
+          .eql('Require Admin access');
         done(err);
       });
   });
@@ -391,6 +372,127 @@ describe('/PATCH Group route', () => {
           .eql(`${group.name}`);
         expect(res.body.data[0]).to.have.property('role')
           .eql('admin');
+        done(err);
+      });
+  });
+});
+
+describe('/DELETE Group route', () => {
+  it('should return an error if user is not authenticated', done => {
+    const group = {
+      id: 1,
+    };
+    chai
+      .request(app)
+      .delete(`/api/v2/groups/${group.id}`)
+      .set('authorization', '')
+      .end((err, res) => {
+        expect(res).to.have.status(401);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('You are not logged in');
+        done(err);
+      });
+  });
+
+  it('should return an error if token cannot be authenticated', done => {
+    const group = {
+      id: 1,
+    };
+    chai
+      .request(app)
+      .delete(`/api/v2/groups/${group.id}`)
+      .set('authorization', 'urgjrigriirkjwUHJFRFFJrgfr')
+      .end((err, res) => {
+        expect(res).to.have.status(401);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Authentication failed');
+        done(err);
+      });
+  });
+
+  it('should return an error if id format is invalid', done => {
+    const group = {
+      id: 'ty',
+    };
+    chai
+      .request(app)
+      .delete(`/api/v2/groups/${group.id}`)
+      .set('authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('The given id is invalid');
+        done(err);
+      });
+  });
+
+  it('should return an error if group does not exist', done => {
+    const group = {
+      id: 4567,
+    };
+    chai
+      .request(app)
+      .delete(`/api/v2/groups/${group.id}`)
+      .set('authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Group does not exist');
+        done(err);
+      });
+  });
+
+  it('should return an error if user does not belong to the group', done => {
+    const group = {
+      id: 3,
+    };
+    chai
+      .request(app)
+      .delete(`/api/v2/groups/${group.id}`)
+      .set('authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('You do not belong to this group');
+        done(err);
+      });
+  });
+
+  it('should return an error if user is not an admin', done => {
+    const group = {
+      id: 2,
+    };
+    chai
+      .request(app)
+      .delete(`/api/v2/groups/${group.id}`)
+      .set('authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        expect(res).to.have.status(401);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Require Admin access');
+        done(err);
+      });
+  });
+
+  it('should delete the group if all relevant details are valid', done => {
+    const group = {
+      id: 1,
+    };
+    chai
+      .request(app)
+      .delete(`/api/v2/groups/${group.id}`)
+      .set('authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data[0]).to.have.property('message')
+          .eql('Group deleted successfully');
         done(err);
       });
   });


### PR DESCRIPTION
#### What does this PR do?

This PR setup test suite and implements delete group endpoint



#### Description of Tasks

- Setup test suite for this endpoint
- Define endpoint and method for delete group
- Add the route
- Secure the route
- Test with Postman
- Ensure spec tests for this endpoint pass



#### How should this be manually tested?


Make a delete request to `/api/v2/groups/<group-id>`

#### Background context

Require admin access

#### Relevant pivotal tracker story

- [164614637](https://www.pivotaltracker.com/story/show/164614637)



#### Screenshots

![Screenshot (17)](https://user-images.githubusercontent.com/43535158/54504288-52a1b580-4933-11e9-92bc-fe59b9bffefb.png)
