### PR TITLE
feat(group): implement delete user endpoint

### DIFF
--- a/server/usingDatabase/controllers/GroupController.js
+++ b/server/usingDatabase/controllers/GroupController.js
@@ -157,6 +157,34 @@ class GroupController {
       });
     });
   }
+
+  /**
+  * @method deleteUser
+  * @description Delete member from a group
+  * @static
+  * @param {object} req - The request object
+  * @param {object} res - The response object
+  * @returns {object} JSON response
+  * @memberof GroupController
+  */
+  static deleteUser(req, res) {
+    const { id } = req.params;
+    const { memberId } = req.params;
+
+    const values = [id, memberId];
+    const query = 'DELETE FROM group_members WHERE group_id = $1 AND member_id = $2';
+
+    pool.query(query, values, err => {
+      if (err) {
+        return ErrorHandler.databaseError(res);
+      }
+
+      return res.status(200).send({
+        status: res.statusCode,
+        data: [{ message: 'Member has been deleted' }],
+      });
+    });
+  }
 }
 
 export default GroupController;

--- a/server/usingDatabase/middlewares/GroupValidator.js
+++ b/server/usingDatabase/middlewares/GroupValidator.js
@@ -179,6 +179,39 @@ class GroupValidator {
       return next();
     });
   }
+
+  /**
+  * @method validateMemberExistence
+  * @description Check if user to be deleted is not in the group
+  * @static
+  * @param {object} req - The request object
+  * @param {object} res - The response object
+  * @param {object} next
+  * @returns {object} next
+  * @memberof GroupValidator
+  */
+  static validateMemberExistence(req, res, next) {
+    const regEx = Helper.regEx();
+    const { id } = req.params;
+    const { memberId } = req.params;
+
+    if ((!regEx.id.test(memberId) || (memberId === '0')) || (!regEx.id.test(id) || (id === '0'))) {
+      return ErrorHandler.validationError(res, 400, 'The given id is invalid');
+    }
+
+    const values = [id, memberId];
+    const query = 'SELECT * FROM group_members WHERE group_id = $1 and member_id = $2';
+
+    pool.query(query, values, (err, data) => {
+      if (err) {
+        return ErrorHandler.databaseError(res);
+      }
+      if (data.rowCount < 1) {
+        return ErrorHandler.validationError(res, 404, 'User does not exist');
+      }
+      return next();
+    });
+  }
 }
 
 export default GroupValidator;

--- a/server/usingDatabase/routes/router.js
+++ b/server/usingDatabase/routes/router.js
@@ -88,4 +88,12 @@ router.post('/groups/:id/users',
   GroupValidator.validateExistingMember,
   GroupController.addMember);
 
+router.delete('/groups/:id/users/:memberId',
+  Auth.userAuth,
+  GroupValidator.validateExistingGroup,
+  GroupValidator.validateMember,
+  GroupValidator.validateAdmin,
+  GroupValidator.validateMemberExistence,
+  GroupController.deleteUser);
+
 export default router;

--- a/server/usingDatabase/seeds/createSeeds.js
+++ b/server/usingDatabase/seeds/createSeeds.js
@@ -120,6 +120,12 @@ const createGroup = `
   VALUES('Liverpool',
     'Anfield is my home')
   RETURNING *;
+
+  INSERT INTO groups(name,
+    description)
+  VALUES('Group4',
+    'This is group 4')
+  RETURNING *;
 `;
 
 const createGroupMember = `
@@ -169,6 +175,22 @@ const createGroupMember = `
   VALUES('3',
     '2',
     'admin')
+  RETURNING *;
+
+  INSERT INTO group_members(group_id,
+    member_id,
+    role)
+  VALUES('4',
+    '1',
+    'admin')
+  RETURNING *;
+
+  INSERT INTO group_members(group_id,
+    member_id,
+    role)
+  VALUES('4',
+    '2',
+    'member')
   RETURNING *;
 `;
 

--- a/server/usingDatabase/tests/groupsSpec.js
+++ b/server/usingDatabase/tests/groupsSpec.js
@@ -631,4 +631,94 @@ describe('/DELETE Group route', () => {
         done(err);
       });
   });
+
+  it('should return an error if id format is invalid', done => {
+    const group = {
+      id: 'ty',
+      memberId: 2,
+    };
+    chai
+      .request(app)
+      .delete(`/api/v2/groups/${group.id}/users/${group.memberId}`)
+      .set('authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('The given id is invalid');
+        done(err);
+      });
+  });
+
+  it('should return an error if group does not exist', done => {
+    const group = {
+      id: 4567,
+      memberId: 2,
+    };
+    chai
+      .request(app)
+      .delete(`/api/v2/groups/${group.id}/users/${group.memberId}`)
+      .set('authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Group does not exist');
+        done(err);
+      });
+  });
+
+  it('should return an error if user does not belong to the group', done => {
+    const group = {
+      id: 3,
+      memberId: 2,
+    };
+    chai
+      .request(app)
+      .delete(`/api/v2/groups/${group.id}/users/${group.memberId}`)
+      .set('authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('You do not belong to this group');
+        done(err);
+      });
+  });
+
+  it('should return an error if user is not an admin', done => {
+    const group = {
+      id: 2,
+      memberId: 2,
+    };
+    chai
+      .request(app)
+      .delete(`/api/v2/groups/${group.id}/users/${group.memberId}`)
+      .set('authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        expect(res).to.have.status(401);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Require Admin access');
+        done(err);
+      });
+  });
+
+  it('should delete a user if all relevant details are valid', done => {
+    const group = {
+      id: 4,
+      memberId: 2,
+    };
+    chai
+      .request(app)
+      .delete(`/api/v2/groups/${group.id}/users/${group.memberId}`)
+      .set('authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data[0]).to.have.property('message')
+          .eql('Member has been deleted');
+        done(err);
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?

This PR setup test suite and implements delete user endpoint


#### Description of Tasks


- Setup test suite for this endpoint
- Define endpoint and method for deleting user from a group
- Add the route
- Secure the route
- Test with Postman
- Ensure spec tests for this endpoint pass

#### How should this be manually tested?


Make a delete request to `/api/v2/groups/<group-id>/users/<member-id>`

#### Background context

Require admin access


#### Relevant pivotal tracker story

- [164617057](https://www.pivotaltracker.com/story/show/164617057)



#### Screenshots

![Screenshot (24)](https://user-images.githubusercontent.com/43535158/54582535-5e63a980-4a11-11e9-811d-297a906f80e9.png)
