### PR TITLE
feat(group): implement send group messages endpoint

### DIFF
--- a/server/usingDatabase/middlewares/GroupValidator.js
+++ b/server/usingDatabase/middlewares/GroupValidator.js
@@ -100,6 +100,22 @@ class GroupValidator {
     });
   }
 
+  static validateGroupMessageFields(req, res, next) {
+    const { subject, message } = req.body;
+
+    if (subject.length > 255) {
+      return ErrorHandler.validationError(res, 400,
+        `subject contains ${subject.length} characters, cannot be greater than 255`);
+    }
+
+    if (!message) {
+      return ErrorHandler.validationError(res, 400,
+        'message field cannot be empty');
+    }
+
+    return next();
+  }
+
   /**
   * @method validateAdmin
   * @description Check if user is a group admin

--- a/server/usingDatabase/routes/router.js
+++ b/server/usingDatabase/routes/router.js
@@ -94,4 +94,12 @@ router.delete('/groups/:id/users/:memberId',
   GroupValidator.validateMemberExistence,
   GroupController.deleteUser);
 
+router.post('/groups/:id/messages',
+  Auth.userAuth,
+  GroupValidator.validateGroupMessageFields,
+  GroupValidator.validateExistingGroup,
+  GroupValidator.validateMember,
+  GroupValidator.validateAdmin,
+  GroupController.postGroupMessage);
+
 export default router;

--- a/server/usingDatabase/seeds/createSeeds.js
+++ b/server/usingDatabase/seeds/createSeeds.js
@@ -38,6 +38,30 @@ const createUser = `
     '${hashed}',
     '08922334455')
   RETURNING *;
+
+  INSERT INTO users(email,
+    firstname,
+    lastname,
+    password,
+    phonenumber)
+  VALUES('viola4@epicmail.com',
+    'Alexis',
+    'Violet',
+    '${hashed}',
+    '08442334455')
+  RETURNING *;
+
+  INSERT INTO users(email,
+    firstname,
+    lastname,
+    password,
+    phonenumber)
+  VALUES('viola5@epicmail.com',
+    'John',
+    'Violet',
+    '${hashed}',
+    '08955334455')
+  RETURNING *;
 `;
 
 const createMessage = `
@@ -147,6 +171,12 @@ const createGroup = `
 
   INSERT INTO groups(name,
     description)
+  VALUES('Liverpool',
+    'Anfield is my home')
+  RETURNING *;
+
+  INSERT INTO groups(name,
+    description)
   VALUES('Group4',
     'This is group 4')
   RETURNING *;
@@ -166,6 +196,30 @@ const createGroupMember = `
     role)
   VALUES('1',
     '2',
+    'member')
+  RETURNING *;
+
+  INSERT INTO group_members(group_id,
+    member_id,
+    role)
+  VALUES('1',
+    '3',
+    'member')
+  RETURNING *;
+
+  INSERT INTO group_members(group_id,
+    member_id,
+    role)
+  VALUES('1',
+    '4',
+    'member')
+  RETURNING *;
+
+  INSERT INTO group_members(group_id,
+    member_id,
+    role)
+  VALUES('1',
+    '5',
     'member')
   RETURNING *;
 

--- a/server/usingDatabase/tests/groupsSpec.js
+++ b/server/usingDatabase/tests/groupsSpec.js
@@ -271,6 +271,127 @@ describe('/POST Group route', () => {
         done(err);
       });
   });
+
+  it('should return an error if SUBJECT field characters is greater than 255', done => {
+    const group = {
+      id: 1,
+      subject: `lorem ipsum tities lorem ipsum tities lorem ipsum tities lorem ipsum tities
+        lorem ipsum tities lorem ipsum tities lorem ipsum tities lorem ipsum tities lorem ipsum
+        lorem ipsum titieslorem ipsum titieslorem ipsum titieslorem ipsum titieslorem ipsum tities`,
+      message: 'Yep, It is here',
+    };
+    chai
+      .request(app)
+      .post(`/api/v2/groups/${group.id}/messages`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql(`subject contains ${group.subject.length} characters, cannot be greater than 255`);
+        done(err);
+      });
+  });
+
+  it('should return an error if MESSAGE field is empty', done => {
+    const group = {
+      id: 1,
+      subject: 'Election News',
+      message: '',
+    };
+    chai
+      .request(app)
+      .post(`/api/v2/groups/${group.id}/messages`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('message field cannot be empty');
+        done(err);
+      });
+  });
+
+  it('should return an error if group does not exist', done => {
+    const group = {
+      id: 66,
+      subject: 'Election News',
+      message: 'lorem ipsum titititititittiies',
+    };
+    chai
+      .request(app)
+      .post(`/api/v2/groups/${group.id}/messages`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Group does not exist');
+        done(err);
+      });
+  });
+
+  it('should return an error if user is not a member of the group', done => {
+    const group = {
+      id: 3,
+      subject: 'Election News',
+      message: 'lorem ipsum titititititittiies',
+    };
+    chai
+      .request(app)
+      .post(`/api/v2/groups/${group.id}/messages`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('You do not belong to this group');
+        done(err);
+      });
+  });
+
+  it('should return an error if user is not an admin', done => {
+    const group = {
+      id: 2,
+      subject: 'Election News',
+      message: 'lorem ipsum titititititittiies',
+    };
+    chai
+      .request(app)
+      .post(`/api/v2/groups/${group.id}/messages`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(401);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error')
+          .eql('Require Admin access');
+        done(err);
+      });
+  });
+
+  it('should send message to group members if credentials are valid', done => {
+    const group = {
+      id: 1,
+      subject: 'Election News',
+      message: 'lorem ipsum titititititittiies',
+    };
+    chai
+      .request(app)
+      .post(`/api/v2/groups/${group.id}/messages`)
+      .set('authorization', `Bearer ${userToken}`)
+      .send(group)
+      .end((err, res) => {
+        expect(res).to.have.status(201);
+        expect(res.body).to.be.an('object');
+        expect(res.body.data).to.be.an('array');
+        done(err);
+      });
+  });
 });
 
 describe('/GET Group route', () => {


### PR DESCRIPTION
#### What does this PR do?


This PR setup test suite and implements send-group-messages endpoint


#### Description of Tasks

- Setup test suite for this endpoint
- Define endpoint and method for send group messages
- Add the route
- Secure the route
- Test with Postman
- Ensure spec tests for this endpoint pass


#### How should this be manually tested?

Make a post request to `/api/v2/groups/<group-id>/messages` endpoint

#### Background context


Require admin access


#### Relevant pivotal tracker story

- [164617394](https://www.pivotaltracker.com/story/show/164617394)



#### Screenshots

![Screenshot (27)](https://user-images.githubusercontent.com/43535158/54703951-15f3db00-4b3a-11e9-8492-27a555b8d04a.png)
